### PR TITLE
docs: corrige sintaxis del diagrama mermaid en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ gitGraph
    merge hotfix/correccion-error tag: "v1.0.1"
    checkout develop
    merge hotfix/correccion-error
+```
+
 ---
 
 ## 🔄 Flujo de Trabajo Aplicado


### PR DESCRIPTION
## Descripción

Se corrige un error de sintaxis en el diagrama Mermaid incluido en el archivo README.md.

El problema era causado por comillas sin cerrar dentro del bloque del gráfico, lo que impedía que GitHub renderizara correctamente el diagrama.

## Tipo de cambio

- Corrección de documentación

## Alcance

Este cambio afecta únicamente al README del repositorio y no modifica el código ni el comportamiento del sistema.

## Issue relacionada

Closes #37